### PR TITLE
Fix "Preemtive" mode name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Factorio-Splatter-Guard
 
-
-
 Stops you being splattered by trains.
+
 ![Splatter Guard Demo](https://media.giphy.com/media/5t5UYRllMIy0jMugxT/giphy.gif)
 
-Preemtive option will constantly check if you are in imminent danger of a train hitting you and teleport you a short distance away to a safe spot before you are hit. The Preemtive option enables the Reactive behaviour as a fall back should the mod fail to detect a danger.
+Preemptive option will constantly check if you are in imminent danger of a train hitting you and teleport you a short distance away to a safe spot before you are hit. The Preemptive option enables the Reactive behaviour as a fallback should the mod fail to detect a danger.
 
 Reactive (Only) option will revert any personal damage done to you by a train and teleport you a short distance away to a safe spot. The train will damage your shields and may be slowed down or damaged itself by the collision.
 
@@ -13,6 +12,6 @@ When a player is teleported they will be held in place for a second to avoid the
 
 Should be fully compatible with all other mods. If another mod makes you invincible you may not jump.
 
-If the Preemtive option is enabled there will be a small UPS cost per player as it has to continuously look for dangers in advance.
+If the Preemptive option is enabled there will be a small UPS cost per player as it has to continuously look for dangers in advance.
 
 Currently if you are not on full health and hit by a train for a lot of damage you may be returned to full health instantly. Shield damage will not be repaired.

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,7 +24,7 @@ Date: 2019-03-13
   Info:
     - Changelog changed to new format
     - refactor code to newer style and compatible with luacheck
-    - move to my common utily lua scripts
+    - move to my common utility lua scripts
 ---------------------------------------------------------------------------------------------------
 Version: 0.1.3
 Date: 2019-11-10
@@ -43,7 +43,7 @@ Date: 2018-11-08
     - Train detection logic changed to be more flexible and lower UPS impact
 	- Protection from players running in to the side of the train, not just the trains front and back.
 	- Option of Reactive Only to train impacts, saving you after a train has hit you.
-	- Preemtive train protection includes the Reactive option as a backup.
+	- Preemptive train protection includes the Reactive option as a backup.
   Changes:
     - Purple smoke effect when a player is teleported to safety
 ---------------------------------------------------------------------------------------------------
@@ -51,4 +51,4 @@ Version: 0.1.0
 Date: 2018-08-23
   Features:
     - Initial Release
-	- Preemtively jumps the player out of the way of incoming trains and holds them safely still.
+	- Preemptively jumps the player out of the way of incoming trains and holds them safely still.

--- a/locale/en/english.cfg
+++ b/locale/en/english.cfg
@@ -4,4 +4,4 @@ train-avoid-mode=Train Avoidance Method
 
 
 [mod-setting-description]
-train-avoid-mode=Preemtive option will try and teleport players to safety before a train hits them, but should it fail then the Reactive option is used as a fall back. Reactive Only option will save the player by teleporting them when the train hits them. This Reactionary protection may slow down or damage the train.
+train-avoid-mode=Preemptive option will try and teleport players to safety before a train hits them, but should it fail then the Reactive option is used as a fallback. Reactive Only option will save the player by teleporting them when the train hits them. This Reactionary protection may slow down or damage the train.

--- a/migrations/00-spelling.lua
+++ b/migrations/00-spelling.lua
@@ -1,0 +1,7 @@
+if settings.global["train-avoid-mode"].value == "Preemtive" then
+    settings.global["train-avoid-mode"].value = "Preemptive"
+end
+
+if global.Mod.Settings.trainAvoidMode == "Preemtive" then
+    global.Mod.Settings.trainAvoidMode = "Preemptive"
+end

--- a/scripts/train_jumper.lua
+++ b/scripts/train_jumper.lua
@@ -116,7 +116,7 @@ function TrainJumper.SetTrainAvoidEvents()
     if global.Mod == nil or global.Mod.Settings == nil or global.Mod.Settings.trainAvoidMode == nil then
         return
     end
-    if global.Mod.Settings.trainAvoidMode == "Preemtive" then
+    if global.Mod.Settings.trainAvoidMode == "Preemptive" then
         script.on_event(defines.events.on_tick, TrainJumper.Manager)
         script.on_event(defines.events.on_entity_damaged, TrainJumper.EntityDamaged)
     elseif global.Mod.Settings.trainAvoidMode == "Reactive Only" then

--- a/settings.lua
+++ b/settings.lua
@@ -3,8 +3,8 @@ data:extend(
         {
             name = "train-avoid-mode",
             type = "string-setting",
-            default_value = "Preemtive",
-            allowed_values = {"Preemtive", "Reactive Only", "None"},
+            default_value = "Preemptive",
+            allowed_values = {"Preemptive", "Reactive Only", "None"},
             setting_type = "runtime-global",
             order = "1001"
         }


### PR DESCRIPTION
Saw [Xterminator's spotlight of this mod](https://www.youtube.com/watch?v=3EMTHzDwCQE) today and thought I could make a small, but useful, contribution.

* Added migration script to convert old saves using the original mode name "Preemtive" to the new name "Preemptive"
  * I tested by adding the released ZIP of 18.1.6 to a copy of one of my test maps, checking its setting value ("Preemtive"), then quitting Factorio and replacing the ZIP with the unzipped folder containing my changes. No errors were thrown, and the stored setting _was_ updated to "Preemptive" as expected upon loading the test map again.
* Fixed whitespace around top of README, especially the animated demo
* Tweaked a couple other minor spelling/grammar errors

----

_If you're so inclined, and you like this PR, having it counted toward my [Hacktoberfest](https://hacktoberfest.digitalocean.com/) statistics would be great! But I still would have opened it regardless, and I completely understand if you don't want to add any label/topic to this PR/repo just for me. 😸_